### PR TITLE
Added background search feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "@pixi/assets": "^6.5.10",
                 "@vercel/analytics": "^1.5.0",
                 "axios": "^1.8.4",
+                "fast-fuzzy": "^1.12.0",
                 "pixi-live2d-display": "^0.4.0",
                 "pixi.js": "^6.5.2",
                 "react": "^19.0.0",
@@ -2872,6 +2873,14 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fast-fuzzy": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/fast-fuzzy/-/fast-fuzzy-1.12.0.tgz",
+            "integrity": "sha512-sXxGgHS+ubYpsdLnvOvJ9w5GYYZrtL9mkosG3nfuD446ahvoWEsSKBP7ieGmWIKVLnaxRDgUJkZMdxRgA2Ni+Q==",
+            "dependencies": {
+                "graphemesplit": "^2.4.1"
+            }
+        },
         "node_modules/fast-glob": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -3269,6 +3278,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/graphemesplit": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/graphemesplit/-/graphemesplit-2.6.0.tgz",
+            "integrity": "sha512-rG9w2wAfkpg0DILa1pjnjNfucng3usON360shisqIMUBw/87pojcBSrHmeE4UwryAuBih7g8m1oilf5/u8EWdQ==",
+            "dependencies": {
+                "js-base64": "^3.6.0",
+                "unicode-trie": "^2.0.0"
+            }
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3411,6 +3429,11 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/js-base64": {
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+            "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -3760,6 +3783,11 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/pako": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+            "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
@@ -4361,6 +4389,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/tiny-inflate": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.12",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
@@ -4501,6 +4534,15 @@
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/unicode-trie": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+            "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+            "dependencies": {
+                "pako": "^0.2.5",
+                "tiny-inflate": "^1.0.0"
             }
         },
         "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "@pixi/assets": "^6.5.10",
         "@vercel/analytics": "^1.5.0",
         "axios": "^1.8.4",
+        "fast-fuzzy": "^1.12.0",
         "pixi-live2d-display": "^0.4.0",
         "pixi.js": "^6.5.2",
         "react": "^19.0.0",

--- a/src/components/BackgroundPicker.tsx
+++ b/src/components/BackgroundPicker.tsx
@@ -22,7 +22,9 @@ const BackgroundPicker: React.FC = () => {
         if (!deferredSearchValue) {
             return data.background;
         }
-        return data.background.filter((bg) => fuzzy(deferredSearchValue, bg) > 0.65);
+        return data.background.filter((bg) => {
+            return fuzzy(deferredSearchValue, bg.replace(/[^a-z0-9]/gi, "")) > 0.5;
+        });
     }, [deferredSearchValue])
 
     const handleChangeBackground = async (bg: string) => {

--- a/src/components/BackgroundPicker.tsx
+++ b/src/components/BackgroundPicker.tsx
@@ -1,4 +1,5 @@
-import React, { useContext, useState } from "react";
+import { fuzzy } from "fast-fuzzy";
+import React, { ChangeEvent, useCallback, useContext, useDeferredValue, useEffect, useMemo, useState } from "react";
 import { AppContext } from "../contexts/AppContext";
 import data from "../background.json";
 import { getBackground } from "../utils/GetBackground";
@@ -11,6 +12,18 @@ const BackgroundPicker: React.FC = () => {
     if (!context) return;
 
     const { background, setBackground } = context;
+
+    const [searchValue, setSearchValue] = useState('');
+    const handleSearchValueChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+        setSearchValue(e.target.value);
+    }, []);
+    const deferredSearchValue = useDeferredValue(searchValue);
+    const filteredBackgrounds = useMemo(() => {
+        if (!deferredSearchValue) {
+            return data.background;
+        }
+        return data.background.filter((bg) => fuzzy(deferredSearchValue, bg) > 0.65);
+    }, [deferredSearchValue])
 
     const handleChangeBackground = async (bg: string) => {
         const backgroundSprite = await getBackground(`/background/${bg}`);
@@ -25,19 +38,49 @@ const BackgroundPicker: React.FC = () => {
         }
     };
 
+    useEffect(() => {
+        const onKeyDown = (keyDownEvent: KeyboardEvent) => {
+            if (keyDownEvent.key === "Escape") {
+                if (searchValue) {
+                    setSearchValue("");
+                } else {
+                    setShow(false);
+                }
+            }
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => {
+            window.removeEventListener("keydown", onKeyDown);
+        };
+    }, [searchValue]);
+
     return (
         <>
             {show && (
                 <div
                     id="picker"
-                    onClick={() => {
-                        setShow(false);
-                    }}
                 >
-                    <button id="picker-close" className="btn-circle btn-pink">
+                    <button
+                        id="picker-close"
+                        className="btn-circle btn-pink"
+                        onClick={() => {
+                            setShow(false);
+                        }}
+                    >
                         <i className="bi bi-x-lg"></i>
                     </button>
-                    {data["background"].map((bg) => {
+                    <input
+                        type="text"
+                        value={searchValue}
+                        onChange={handleSearchValueChange}
+                        placeholder="Search background"
+                        style={{
+                            position: "fixed",
+                            top: 10,
+                            width: '80%',
+                        }}
+                    />
+                    {filteredBackgrounds.map((bg) => {
                         return (
                             <div
                                 key={bg}


### PR DESCRIPTION
## What was done
- Added search bar to search for backgrounds based on their file names using [`fast-fuzzy`](https://github.com/EthanRutherford/fast-fuzzy#readme).
- Added `keydown` listener:
  - When press escape and search bar is empty, closes the background picker,
  - When press escape key and search bar is _not_ empty, clears the search bar instead.

## Showcase
Screenshot below shows search results containing "mizuki" as keyword:
<img width="1722" alt="f916fb17-ded5-4beb-b66b-98ba3d654e4c" src="https://github.com/user-attachments/assets/2bbe47cb-b1bc-44a3-98a2-379a9eba4611" />

## Notes
- This feature can be enhanced by modifying `background.json` to store search metadata alongside the file names.
- Example:
```json
{
  [
    {
      "path": "Background_25-ji_Nightcord_de_Opening_CG.png",
      "keywords": [
        "niigo",
        "n25",
        "kanade",
      ],
    }
  ]
}
```